### PR TITLE
fix(layout): calculate node size according to collapsed status

### DIFF
--- a/tool/app/layout/layout.js
+++ b/tool/app/layout/layout.js
@@ -337,11 +337,18 @@ const convert = function (data) {
             const size = _.find( istar.graph.getElements(), { id: id } ).get("size")
             if (!size)
                 throw Error('Illegal node size ' + obj.id)
-            const [width, height] = [size.width, size.height]
+            let [width, height] = [size.width, size.height]
 
             reverse[id] = id
             if (obj.nodes) {
                 _.forEach(obj.nodes, item => (reverse[item.id] = id))
+            }
+            if (data.display && data.display[id] && data.display[id].collapsed) {
+                const normalSize = dictionary.nodeSize[desc]
+                if (normalSize) {
+                    width = normalSize[0]
+                    height = normalSize[1]
+                }
             }
 
             const r = (height > width ? height : width) / 2


### PR DESCRIPTION
Fix the size calculation during layout. Now the method would check whether nodes are collapsed, and use the actual visible sizes to calculate and perform the layout.