### PR TITLE
fix: check failing if coordinate is 0

### DIFF
--- a/tool/app/istarcore/fileManager.js
+++ b/tool/app/istarcore/fileManager.js
@@ -413,7 +413,7 @@ istar.fileManager = function() {
             }
 
             function addLoadedElement (element, display) {
-                if (element.id && element.type && element.x && element.y) {
+                if (element.id && element.type && typeof element.x === 'number' && typeof element.y === 'number' ) {
                     element.text = element.text || '';
                     var type = element.type.split('.')[1];
                     if (istar['add' + type]) {


### PR DESCRIPTION
## Description
After saving a model which has an element with a coordinate set to 0 the loading of that model will fail. This is because the 0 is treated as a falsy value in `addLoadedElement` and the if condition is not satisfied. 

In my case a dependum had a coordinate 0 and was set left on `undefined`, then the loading crashed in `fileManager.js:348` when accessing `dependum.type` and the dependum is not defined.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/58e24fc2-98df-4e01-bf43-f5a77c014836" />


## Fix
Use `typeof` to explicitly check that x and y are numbers.